### PR TITLE
Use Symfony Filesystem to create export directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "symfony/serializer-pack": "^1.3",
     "phpoffice/phpspreadsheet": "^3.9",
     "symfony/dependency-injection": "6.*|7.*",
-    "symfony/config": "6.*|7.*"
+    "symfony/config": "6.*|7.*",
+    "symfony/filesystem": "^6.0"
   },
   "autoload": {
     "psr-4": { "Akyos\\UXExportBundle\\": "src/" },


### PR DESCRIPTION
## Summary
- use Symfony Filesystem to manage export directory creation
- require symfony/filesystem component

## Testing
- `composer install --no-interaction` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a73e809c83308dfd55398fb3ce34