### PR TITLE
Fix populateData when exporting using methods

### DIFF
--- a/src/Service/ExporterService.php
+++ b/src/Service/ExporterService.php
@@ -32,7 +32,11 @@ class ExporterService
 
         foreach ($data as $rowIndex => $item) {
             foreach ($properties as $colIndex => $property) {
-                $value = $propertyAccessor->getValue($item, $property->getName());
+                if ($property instanceof \ReflectionMethod) {
+                    $value = $property->invoke($item);
+                } else {
+                    $value = $propertyAccessor->getValue($item, $property->getName());
+                }
                 $spreadsheet->getActiveSheet()->setCellValue([$colIndex + 1, $rowIndex + 2], $value);
             }
         }


### PR DESCRIPTION
## Summary
- properly handle reflection methods in `ExporterService::populateData`

## Testing
- `php -l src/Service/ExporterService.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68429f88bf348330b5c1833c6a549da0