### PR TITLE
Improve test coverage for CSV exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Applications that use Symfony Flex
 Open a command console, enter your project directory and execute:
 
 ```console
-composer require <package-name>
+composer require akyos/ux-export
 ```
 
 Applications that don't use Symfony Flex
@@ -23,7 +23,7 @@ Open a command console, enter your project directory and execute the
 following command to download the latest stable version of this bundle:
 
 ```console
-composer require <package-name>
+composer require akyos/ux-export
 ```
 
 ### Step 2: Enable the Bundle
@@ -36,16 +36,40 @@ in the `config/bundles.php` file of your project:
 
 return [
     // ...
-    <vendor>\<bundle-name>\<bundle-long-name>::class => ['all' => true],
+    Akyos\UXExportBundle\UXExportBundle::class => ['all' => true],
 ];
 ```
+
+Configuration
+-------------
+
+The bundle writes generated files under `ux_export.path`. The default path is
+`%kernel.project_dir%/var/export/`. It can be overridden in
+`config/packages/ux_export.yaml`:
+
+```yaml
+ux_export:
+    path: '%kernel.project_dir%/var/export/'
+```
+
+Defining Exportable Entities
+----------------------------
+
+Mark your entities with `#[Exportable]` and use `#[ExportableProperty]` to
+control what is exported. Properties or methods tagged with these attributes
+are listed in the export if their `groups` option matches the group defined on
+the `Exportable` attribute. You may also rely on Symfony's `#[Groups]`
+attribute as a fallback.
 
 Usage of Exportable Attributes
 ------------------------------
 
-The `ExportableProperty` attribute accepts two new options:
+`ExportableProperty` exposes several options:
 
-- `fields`: an array of property names to export from a related entity.
+- `groups`: serializer groups allowed for this column.
+- `name`: override the column header.
+- `position`: integer used to order columns.
+- `fields`: extract sub-fields from a related entity.
 - `manyToMany`: set to `lines` to duplicate rows for each relation or to
   `sheet` to create an additional worksheet listing the intermediate table.
 
@@ -55,3 +79,126 @@ Example:
 #[ExportableProperty(groups: ['export'], fields: ['name', 'email'], manyToMany: ExportableProperty::MODE_SHEET)]
 private Collection $users;
 ```
+
+### Exporting Nested Fields
+
+The `fields` option allows you to export properties from a related entity:
+
+```php
+#[Exportable]
+class Order
+{
+    #[ExportableProperty(groups: ['export'], fields: ['firstName', 'lastName'])]
+    private ?Customer $customer = null;
+}
+```
+
+### Many-to-many Relations
+
+Use the `manyToMany` option when dealing with collections:
+
+```php
+// duplicate one row per related entity
+#[ExportableProperty(groups: ['export'], manyToMany: ExportableProperty::MODE_LINES)]
+private Collection $tags;
+
+// or create a dedicated worksheet listing the relations
+#[ExportableProperty(groups: ['export'], fields: ['name'], manyToMany: ExportableProperty::MODE_SHEET)]
+private Collection $roles;
+```
+
+### Export Values from Methods
+
+Methods can also be exported:
+
+```php
+#[Exportable]
+class User
+{
+    #[ExportableProperty(groups: ['export'], name: 'Full name', position: 1)]
+    public function getFullName(): string
+    {
+        return $this->firstName.' '.$this->lastName;
+    }
+}
+```
+
+Live Component Integration
+--------------------------
+
+Include `ComponentWithExportTrait` in a Symfony UX Live Component. Implement
+`getData()` to provide the dataset (an array, a Doctrine `QueryBuilder` or a
+`Query`). Set the `$class` property so the trait can read your entity metadata:
+
+```php
+use Akyos\UXExportBundle\Trait\ComponentWithExportTrait;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+
+#[AsLiveComponent]
+class UserTableComponent
+{
+    use ComponentWithExportTrait;
+
+    public string $class = User::class;
+
+    private UserRepository $repository;
+
+    public function __construct(UserRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function getData(): iterable
+    {
+        return $this->repository->createQueryBuilder('u')->getQuery();
+    }
+}
+```
+
+Calling the `export` action generates the file and redirects the browser to the
+download route provided by the bundle.
+
+### Export Formats
+
+The trait supports two formats controlled by the `$exportType` property:
+
+- `xlsx` (default)
+- `csv`
+
+When exporting to CSV, a file is created for each worksheet. If some
+`ExportableProperty` fields use the `manyToMany` option set to `sheet`, an
+additional CSV is generated for that relation and all files are zipped together.
+
+### Using CSV Export
+
+Set the trait's `$exportType` property to `csv` and optionally customize
+`$exportFileName` when you prefer CSV instead of XLSX:
+
+```php
+#[AsLiveComponent]
+class UserTableComponent
+{
+    use ComponentWithExportTrait;
+
+    public string $class = User::class;
+    public string $exportType = 'csv';
+    public string $exportFileName = 'users';
+
+    private UserRepository $repository;
+
+    public function __construct(UserRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function getData(): iterable
+    {
+        return $this->repository->createQueryBuilder('u')->getQuery();
+    }
+}
+```
+
+The bundle will generate a single CSV by default. If one of your
+`ExportableProperty` definitions uses `manyToMany: ExportableProperty::MODE_SHEET`,
+multiple CSV files will be produced and automatically zipped.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,15 @@
+
+# UX Export Bundle
+
+This bundle provides utilities to export data from Symfony UX Live Components
+using PhpSpreadsheet. Refer to the project README for installation details.
+
+Key features:
+
+* `ExporterService` for creating XLSX files
+* `CsvExporterService` for exporting CSV or zipped CSV files
+* `ComponentWithExportTrait` to easily add an `export` action
+* Attributes to configure which entity properties are exported
+* Set `$exportType` to `csv` for plain CSV output or zipped files when a relation uses the `sheet` mode
+
+See the README for detailed examples of `Exportable` and `ExportableProperty`.

--- a/src/Service/CsvExporterService.php
+++ b/src/Service/CsvExporterService.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Akyos\UXExportBundle\Service;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Csv;
+use ZipArchive;
+
+class CsvExporterService
+{
+    private ExporterService $exporterService;
+
+    public function __construct(ExporterService $exporterService)
+    {
+        $this->exporterService = $exporterService;
+    }
+
+    /**
+     * Generate CSV files from data and properties.
+     * Returns the path of the generated file (CSV or ZIP).
+     */
+    public function export(array $data, array $properties, string $path, string $baseName): string
+    {
+        $spreadsheet = new Spreadsheet();
+        $this->exporterService->generateMatrix($spreadsheet, $properties);
+        $this->exporterService->populateData($spreadsheet, $data, $properties);
+
+        $files = [];
+        foreach ($spreadsheet->getAllSheets() as $index => $sheet) {
+            $csvWriter = new Csv($spreadsheet);
+            $csvWriter->setSheetIndex($index);
+
+            $suffix = $index === 0 ? '' : '_' . $sheet->getTitle();
+            $filePath = rtrim($path, '/').'/'.$baseName.$suffix.'.csv';
+            $csvWriter->save($filePath);
+            $files[] = $filePath;
+        }
+
+        if (count($files) === 1) {
+            return $files[0];
+        }
+
+        $zipPath = rtrim($path, '/').'/'.$baseName.'.zip';
+        $zip = new ZipArchive();
+        $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        foreach ($files as $file) {
+            $zip->addFile($file, basename($file));
+        }
+        $zip->close();
+
+        foreach ($files as $file) {
+            @unlink($file);
+        }
+
+        return $zipPath;
+    }
+}

--- a/tests/Service/CsvExporterServiceTest.php
+++ b/tests/Service/CsvExporterServiceTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Akyos\UXExportBundle\Tests\Service;
+
+use Akyos\UXExportBundle\Service\CsvExporterService;
+use Akyos\UXExportBundle\Service\ExporterService;
+use Akyos\UXExportBundle\Attribute\ExportableProperty;
+use Akyos\UXExportBundle\Attribute\Exportable;
+use PHPUnit\Framework\TestCase;
+
+class CsvExporterServiceTest extends TestCase
+{
+    private CsvExporterService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new CsvExporterService(new ExporterService());
+    }
+
+    public function testExportReturnsCsv(): void
+    {
+        $data = [new SimpleUser('john', 'john@example.com')];
+        $reflection = new \ReflectionClass(SimpleUser::class);
+        $properties = $reflection->getProperties();
+        $file = $this->service->export($data, $properties, sys_get_temp_dir().'/', 'csv_test');
+
+        $this->assertFileExists($file);
+        $this->assertStringEndsWith('.csv', $file);
+        @unlink($file);
+    }
+
+    public function testExportWithSheetReturnsZip(): void
+    {
+        $data = [new UserWithRoles([new Role('admin'), new Role('user')])];
+        $reflection = new \ReflectionClass(UserWithRoles::class);
+        $properties = $reflection->getProperties();
+        $file = $this->service->export($data, $properties, sys_get_temp_dir().'/', 'csv_zip');
+
+        $this->assertFileExists($file);
+        $this->assertStringEndsWith('.zip', $file);
+        @unlink($file);
+    }
+
+    public function testZipContainsAllCsvs(): void
+    {
+        $data = [new UserWithRoles([new Role('admin'), new Role('user')])];
+        $reflection = new \ReflectionClass(UserWithRoles::class);
+        $properties = $reflection->getProperties();
+        $file = $this->service->export($data, $properties, sys_get_temp_dir().'/', 'content');
+
+        $zip = new \ZipArchive();
+        $zip->open($file);
+        $this->assertSame(2, $zip->numFiles);
+        $names = [];
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $names[] = $zip->getNameIndex($i);
+        }
+        sort($names);
+        $this->assertSame(['content.csv', 'content_roles.csv'], $names);
+        $zip->close();
+
+        @unlink($file);
+    }
+}
+
+#[Exportable]
+class SimpleUser
+{
+    #[ExportableProperty(groups: ['default'])]
+    public string $username;
+
+    #[ExportableProperty(groups: ['default'])]
+    public string $email;
+
+    public function __construct(string $username, string $email)
+    {
+        $this->username = $username;
+        $this->email = $email;
+    }
+}
+
+#[Exportable]
+class UserWithRoles
+{
+    #[ExportableProperty(groups: ['default'], fields: ['name'], manyToMany: ExportableProperty::MODE_SHEET)]
+    public array $roles;
+
+    public function __construct(array $roles)
+    {
+        $this->roles = $roles;
+    }
+}
+
+class Role
+{
+    public function __construct(public string $name) {}
+}


### PR DESCRIPTION
## Summary
- expand ExporterService tests to cover method export and many-to-many modes
- verify zipped CSV contents in CsvExporterService tests
- document CSV usage and zipped files

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --testdox` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6842ac234ef883309bb101af670ad94a