### PR TITLE
Fix many-to-many export

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Applications that use Symfony Flex
 Open a command console, enter your project directory and execute:
 
 ```console
-composer require <package-name>
+composer require akyos/ux-export
 ```
 
 Applications that don't use Symfony Flex
@@ -23,7 +23,7 @@ Open a command console, enter your project directory and execute the
 following command to download the latest stable version of this bundle:
 
 ```console
-composer require <package-name>
+composer require akyos/ux-export
 ```
 
 ### Step 2: Enable the Bundle
@@ -36,16 +36,41 @@ in the `config/bundles.php` file of your project:
 
 return [
     // ...
-    <vendor>\<bundle-name>\<bundle-long-name>::class => ['all' => true],
+    Akyos\UXExportBundle\UXExportBundle::class => ['all' => true],
 ];
 ```
+
+Configuration
+-------------
+
+The bundle writes generated files under `ux_export.path`. The default path is
+`%kernel.project_dir%/var/export/`. It can be overridden in
+`config/packages/ux_export.yaml`:
+
+```yaml
+ux_export:
+    path: '%kernel.project_dir%/var/export/'
+```
+
+Defining Exportable Entities
+----------------------------
+
+Mark your entities with `#[Exportable]` and use `#[ExportableProperty]` to
+control what is exported. Properties or methods tagged with these attributes
+are listed in the export when their `groups` option matches the group passed to
+the exporter. You may also rely on Symfony's `#[Groups]` attribute as a
+fallback.
 
 Usage of Exportable Attributes
 ------------------------------
 
-The `ExportableProperty` attribute accepts two new options:
+`ExportableProperty` exposes several options:
 
-- `fields`: an array of property names to export from a related entity.
+- `groups`: serializer groups allowed for this column.
+- `name`: override the column header.
+- `position`: integer used to order columns.
+- `fields`: extract sub-fields from a related entity.
+ - `fields`: extract sub-fields from a related entity. When omitted, fields having the same group on the related entity are exported automatically.
 - `manyToMany`: set to `lines` to duplicate rows for each relation or to
   `sheet` to create an additional worksheet listing the intermediate table.
 
@@ -55,3 +80,128 @@ Example:
 #[ExportableProperty(groups: ['export'], fields: ['name', 'email'], manyToMany: ExportableProperty::MODE_SHEET)]
 private Collection $users;
 ```
+
+### Exporting Nested Fields
+
+The `fields` option allows you to export specific properties from a related entity. If omitted, the exporter will automatically include every property of the child entity that belongs to the selected group:
+
+```php
+#[Exportable]
+class Order
+{
+    #[ExportableProperty(groups: ['export'], fields: ['firstName', 'lastName'])]
+    private ?Customer $customer = null;
+}
+```
+
+### Many-to-many Relations
+
+Use the `manyToMany` option when dealing with collections:
+
+```php
+// duplicate one row per related entity
+#[ExportableProperty(groups: ['export'], manyToMany: ExportableProperty::MODE_LINES)]
+private Collection $tags;
+
+// or create a dedicated worksheet listing the relations
+#[ExportableProperty(groups: ['export'], manyToMany: ExportableProperty::MODE_SHEET)]
+private Collection $roles;
+```
+
+### Export Values from Methods
+
+Methods can also be exported:
+
+```php
+#[Exportable]
+class User
+{
+    #[ExportableProperty(groups: ['export'], name: 'Full name', position: 1)]
+    public function getFullName(): string
+    {
+        return $this->firstName.' '.$this->lastName;
+    }
+}
+```
+
+Live Component Integration
+--------------------------
+
+Include `ComponentWithExportTrait` in a Symfony UX Live Component. Implement
+`getData()` to provide the dataset (an array, a Doctrine `QueryBuilder` or a
+`Query`). Set the `$class` property so the trait can read your entity metadata:
+
+```php
+use Akyos\UXExportBundle\Trait\ComponentWithExportTrait;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+
+#[AsLiveComponent]
+class UserTableComponent
+{
+    use ComponentWithExportTrait;
+
+    public string $class = User::class;
+    public ?string $exportGroup = 'default';
+
+    private UserRepository $repository;
+
+    public function __construct(UserRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function getData(): iterable
+    {
+        return $this->repository->createQueryBuilder('u')->getQuery();
+    }
+}
+```
+
+Calling the `export` action generates the file and redirects the browser to the
+download route provided by the bundle.
+
+### Export Formats
+
+The trait supports two formats controlled by the `$exportType` property:
+
+- `xlsx` (default)
+- `csv`
+
+When exporting to CSV, a file is created for each worksheet. If some
+`ExportableProperty` fields use the `manyToMany` option set to `sheet`, an
+additional CSV is generated for that relation and all files are zipped together.
+
+### Using CSV Export
+
+Set the trait's `$exportType` property to `csv` and optionally customize
+`$exportFileName` when you prefer CSV instead of XLSX:
+
+```php
+#[AsLiveComponent]
+class UserTableComponent
+{
+    use ComponentWithExportTrait;
+
+    public string $class = User::class;
+    public string $exportType = 'csv';
+    public string $exportFileName = 'users';
+    public ?string $exportGroup = 'default';
+
+    private UserRepository $repository;
+
+    public function __construct(UserRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function getData(): iterable
+    {
+        return $this->repository->createQueryBuilder('u')->getQuery();
+    }
+}
+```
+
+The bundle will generate a single CSV by default. If one of your
+`ExportableProperty` definitions uses `manyToMany: ExportableProperty::MODE_SHEET`,
+multiple CSV files will be produced and automatically zipped.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,16 @@
+
+# UX Export Bundle
+
+This bundle provides utilities to export data from Symfony UX Live Components
+using PhpSpreadsheet. Refer to the project README for installation details.
+
+Key features:
+
+* `ExporterService` for creating XLSX files
+* `CsvExporterService` for exporting CSV or zipped CSV files
+* `ComponentWithExportTrait` to easily add an `export` action
+* Attributes to configure which entity properties are exported
+* Set `$exportType` to `csv` for plain CSV output or zipped files when a relation uses the `sheet` mode
+* Choose the serializer group at runtime with the `$exportGroup` property
+
+See the README for detailed examples of `Exportable` and `ExportableProperty`.

--- a/src/Attribute/Exportable.php
+++ b/src/Attribute/Exportable.php
@@ -7,7 +7,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS)]
 class Exportable
 {
-    public function __construct(
-        public ?string $group = null
-    ) {}
+    public function __construct()
+    {
+    }
 }

--- a/src/Service/CsvExporterService.php
+++ b/src/Service/CsvExporterService.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Akyos\UXExportBundle\Service;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Csv;
+use ZipArchive;
+
+class CsvExporterService
+{
+    private ExporterService $exporterService;
+
+    public function __construct(ExporterService $exporterService)
+    {
+        $this->exporterService = $exporterService;
+    }
+
+    /**
+     * Generate CSV files from data and properties.
+     * Returns the path of the generated file (CSV or ZIP).
+     */
+    public function export(array $data, array $properties, string $path, string $baseName, ?string $group = null): string
+    {
+        $spreadsheet = new Spreadsheet();
+        $this->exporterService->generateMatrix($spreadsheet, $properties, $data, $group);
+        $this->exporterService->populateData($spreadsheet, $data, $properties, $group);
+
+        $files = [];
+        foreach ($spreadsheet->getAllSheets() as $index => $sheet) {
+            $csvWriter = new Csv($spreadsheet);
+            $csvWriter->setSheetIndex($index);
+
+            $suffix = $index === 0 ? '' : '_' . $sheet->getTitle();
+            $filePath = rtrim($path, '/').'/'.$baseName.$suffix.'.csv';
+            $csvWriter->save($filePath);
+            $files[] = $filePath;
+        }
+
+        if (count($files) === 1) {
+            return $files[0];
+        }
+
+        $zipPath = rtrim($path, '/').'/'.$baseName.'.zip';
+        $zip = new ZipArchive();
+        $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        foreach ($files as $file) {
+            $zip->addFile($file, basename($file));
+        }
+        $zip->close();
+
+        foreach ($files as $file) {
+            @unlink($file);
+        }
+
+        return $zipPath;
+    }
+}

--- a/src/Service/ExporterService.php
+++ b/src/Service/ExporterService.php
@@ -19,7 +19,7 @@ class ExporterService
         };
     }
 
-    public function generateMatrix(Spreadsheet $spreadsheet, array $properties): void
+    public function generateMatrix(Spreadsheet $spreadsheet, array $properties, array $data = [], ?string $group = null): void
     {
         $columnIndex = 1;
         foreach ($properties as $property) {
@@ -29,7 +29,13 @@ class ExporterService
                 continue;
             }
 
-            $fields = $attribute?->fields ?? [null];
+            $fields = $attribute?->fields;
+            if ($fields === null) {
+                $fields = $this->getRelatedFields($property, $data, $group);
+                if (empty($fields)) {
+                    $fields = [null];
+                }
+            }
 
             foreach ($fields as $field) {
                 $name = $this->getPropertyName($property, $field);
@@ -39,20 +45,48 @@ class ExporterService
         }
     }
 
-    public function populateData(Spreadsheet $spreadsheet, array $data, array $properties): void
+    public function populateData(Spreadsheet $spreadsheet, array $data, array $properties, ?string $group = null): void
     {
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
-        foreach ($data as $rowIndex => $item) {
-            foreach ($properties as $colIndex => $property) {
-                if ($property instanceof \ReflectionMethod) {
-                    $value = $property->invoke($item);
-                } else {
-                    $value = $propertyAccessor->getValue($item, $property->getName());
+
+        $rowIndex = 2;
+        foreach ($data as $item) {
+            $lines = $this->getLinesCount($item, $properties, $propertyAccessor);
+            for ($line = 0; $line < $lines; $line++) {
+                $columnIndex = 1;
+                foreach ($properties as $property) {
+                    $attribute = $this->getAttribute($property);
+
+                    if ($attribute && $attribute->manyToMany === ExportableProperty::MODE_SHEET) {
+                        continue;
+                    }
+
+                    if ($property instanceof \ReflectionMethod) {
+                        $value = $property->invoke($item);
+                    } else {
+                        $value = $propertyAccessor->getValue($item, $property->getName());
+                    }
+
+                    if ($attribute && $attribute->manyToMany === ExportableProperty::MODE_LINES) {
+                        $value = ($value[$line] ?? null);
+                    }
+
+                    $fields = $attribute?->fields;
+                    if ($fields === null) {
+                        $fields = $this->getRelatedFields($property, [$value], $group);
+                    }
+                    $values = $this->extractValues($value, $fields, $propertyAccessor, $group);
+
+                    foreach ($values as $val) {
+                        $spreadsheet->getActiveSheet()->setCellValue([$columnIndex, $rowIndex], $val);
+                        $columnIndex++;
+                    }
                 }
-                $spreadsheet->getActiveSheet()->setCellValue([$colIndex + 1, $rowIndex + 2], $value);
+                $rowIndex++;
             }
         }
-        $this->populateManyToManySheets($spreadsheet, $data, $properties, $propertyAccessor);
+
+        $this->populateManyToManySheets($spreadsheet, $data, $properties, $propertyAccessor, $group);
     }
 
     public function manyToManyLines(iterable $collection, string $property): string
@@ -99,7 +133,7 @@ class ExporterService
         return !empty($attributes) ? $attributes[0]->newInstance() : null;
     }
 
-    private function extractValues(mixed $value, ?array $fields, $accessor): array
+    private function extractValues(mixed $value, ?array $fields, $accessor, ?string $group): array
     {
         if ($fields) {
             $vals = [];
@@ -108,6 +142,18 @@ class ExporterService
             }
 
             return $vals;
+        }
+
+        if (is_object($value)) {
+            $fields = $this->getFieldsFromEntity(get_class($value), $group);
+            if ($fields) {
+                $vals = [];
+                foreach ($fields as $field) {
+                    $vals[] = $accessor->getValue($value, $field);
+                }
+
+                return $vals;
+            }
         }
 
         return [$value];
@@ -133,7 +179,7 @@ class ExporterService
         return $max;
     }
 
-    private function populateManyToManySheets(Spreadsheet $spreadsheet, array $data, array $properties, $accessor): void
+    private function populateManyToManySheets(Spreadsheet $spreadsheet, array $data, array $properties, $accessor, ?string $group): void
     {
         foreach ($properties as $property) {
             $attribute = $this->getAttribute($property);
@@ -146,7 +192,8 @@ class ExporterService
 
             $headerIndex = 1;
             $sheet->setCellValue([1, 1], 'row');
-            foreach ($attribute->fields ?? [] as $field) {
+            $fields = $attribute->fields ?? $this->getRelatedFields($property, $data, $group);
+            foreach ($fields as $field) {
                 $sheet->setCellValue([$headerIndex + 1, 1], $field);
                 $headerIndex++;
             }
@@ -160,7 +207,7 @@ class ExporterService
                 foreach ($collection as $element) {
                     $sheet->setCellValue([1, $rowIndex], $i + 1);
                     $colIndex = 2;
-                    foreach ($attribute->fields ?? [] as $field) {
+                    foreach ($fields as $field) {
                         $sheet->setCellValue([$colIndex, $rowIndex], $accessor->getValue($element, $field));
                         $colIndex++;
                     }
@@ -168,5 +215,68 @@ class ExporterService
                 }
             }
         }
+    }
+
+    private function getRelatedFields(\ReflectionProperty|\ReflectionMethod $property, array $data, ?string $group): array
+    {
+        $class = $this->detectClass($property, $data);
+        if (!$class) {
+            return [];
+        }
+
+        return $this->getFieldsFromEntity($class, $group);
+    }
+
+    private function detectClass(\ReflectionProperty|\ReflectionMethod $property, array $data): ?string
+    {
+        if ($property instanceof \ReflectionProperty) {
+            $type = $property->getType();
+            if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
+                return $type->getName();
+            }
+        } elseif ($property instanceof \ReflectionMethod) {
+            $type = $property->getReturnType();
+            if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
+                return $type->getName();
+            }
+        }
+
+        foreach ($data as $item) {
+            if ($property instanceof \ReflectionProperty) {
+                $val = PropertyAccess::createPropertyAccessor()->getValue($item, $property->getName());
+            } else {
+                $val = $property->invoke($item);
+            }
+
+            if (is_iterable($val)) {
+                foreach ($val as $element) {
+                    if (is_object($element)) {
+                        return get_class($element);
+                    }
+                }
+            } elseif (is_object($val)) {
+                return get_class($val);
+            }
+        }
+
+        return null;
+    }
+
+    private function getFieldsFromEntity(string $class, ?string $group): array
+    {
+        $reflection = new \ReflectionClass($class);
+        $fields = [];
+        foreach ($reflection->getProperties() as $prop) {
+            $attr = $prop->getAttributes(ExportableProperty::class);
+            if (!$attr) {
+                continue;
+            }
+            $inst = $attr[0]->newInstance();
+            if ($group === null || in_array($group, $inst->groups)) {
+                $fields[] = $prop->getName();
+            }
+        }
+
+        return $fields;
     }
 }

--- a/tests/Service/CsvExporterServiceTest.php
+++ b/tests/Service/CsvExporterServiceTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Akyos\UXExportBundle\Tests\Service;
+
+use Akyos\UXExportBundle\Service\CsvExporterService;
+use Akyos\UXExportBundle\Service\ExporterService;
+use Akyos\UXExportBundle\Attribute\ExportableProperty;
+use Akyos\UXExportBundle\Attribute\Exportable;
+use PHPUnit\Framework\TestCase;
+
+class CsvExporterServiceTest extends TestCase
+{
+    private CsvExporterService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new CsvExporterService(new ExporterService());
+    }
+
+    public function testExportReturnsCsv(): void
+    {
+        $data = [new SimpleUser('john', 'john@example.com')];
+        $reflection = new \ReflectionClass(SimpleUser::class);
+        $properties = $reflection->getProperties();
+        $file = $this->service->export($data, $properties, sys_get_temp_dir().'/', 'csv_test', 'default');
+
+        $this->assertFileExists($file);
+        $this->assertStringEndsWith('.csv', $file);
+        @unlink($file);
+    }
+
+    public function testExportWithSheetReturnsZip(): void
+    {
+        $data = [new UserWithRoles([new Role('admin'), new Role('user')])];
+        $reflection = new \ReflectionClass(UserWithRoles::class);
+        $properties = $reflection->getProperties();
+        $file = $this->service->export($data, $properties, sys_get_temp_dir().'/', 'csv_zip', 'default');
+
+        $this->assertFileExists($file);
+        $this->assertStringEndsWith('.zip', $file);
+        @unlink($file);
+    }
+
+    public function testZipContainsAllCsvs(): void
+    {
+        $data = [new UserWithRoles([new Role('admin'), new Role('user')])];
+        $reflection = new \ReflectionClass(UserWithRoles::class);
+        $properties = $reflection->getProperties();
+        $file = $this->service->export($data, $properties, sys_get_temp_dir().'/', 'content', 'default');
+
+        $zip = new \ZipArchive();
+        $zip->open($file);
+        $this->assertSame(2, $zip->numFiles);
+        $names = [];
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $names[] = $zip->getNameIndex($i);
+        }
+        sort($names);
+        $this->assertSame(['content.csv', 'content_roles.csv'], $names);
+        $zip->close();
+
+        @unlink($file);
+    }
+}
+
+#[Exportable]
+class SimpleUser
+{
+    #[ExportableProperty(groups: ['default'])]
+    public string $username;
+
+    #[ExportableProperty(groups: ['default'])]
+    public string $email;
+
+    public function __construct(string $username, string $email)
+    {
+        $this->username = $username;
+        $this->email = $email;
+    }
+}
+
+#[Exportable]
+class UserWithRoles
+{
+    #[ExportableProperty(groups: ['default'], manyToMany: ExportableProperty::MODE_SHEET)]
+    public array $roles;
+
+    public function __construct(array $roles)
+    {
+        $this->roles = $roles;
+    }
+}
+
+#[Exportable]
+class Role
+{
+    #[ExportableProperty(groups: ['default'])]
+    public string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Service/ExporterServiceTest.php
+++ b/tests/Service/ExporterServiceTest.php
@@ -23,7 +23,7 @@ class ExporterServiceTest extends TestCase
         $reflection = new \ReflectionClass(Dummy::class);
         $properties = $reflection->getProperties();
 
-        $this->service->generateMatrix($spreadsheet, $properties);
+        $this->service->generateMatrix($spreadsheet, $properties, [], 'default');
 
         $sheet = $spreadsheet->getActiveSheet();
         $this->assertSame('username', $sheet->getCell([1,1])->getValue());
@@ -48,6 +48,58 @@ class ExporterServiceTest extends TestCase
         $this->assertSame('admin', $sheet->getCell([1,1])->getValue());
         $this->assertSame('user', $sheet->getCell([1,2])->getValue());
     }
+
+    public function testPopulateDataWithMethod(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $reflection = new \ReflectionClass(DummyWithMethod::class);
+        $properties = array_merge(
+            $reflection->getProperties(),
+            [$reflection->getMethod('getFullName')]
+        );
+        $this->service->generateMatrix($spreadsheet, $properties, [], 'default');
+
+        $data = [new DummyWithMethod('John', 'Doe')];
+        $this->service->populateData($spreadsheet, $data, $properties, 'default');
+
+        $sheet = $spreadsheet->getActiveSheet();
+        $this->assertSame('Full name', $sheet->getCell([3,1])->getValue());
+        $this->assertSame('John Doe', $sheet->getCell([3,2])->getValue());
+    }
+
+    public function testPopulateDataManyToManyLines(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $reflection = new \ReflectionClass(UserWithRolesLines::class);
+        $properties = $reflection->getProperties();
+        $this->service->generateMatrix($spreadsheet, $properties, [], 'default');
+
+        $data = [new UserWithRolesLines([new Role('admin'), new Role('user')])];
+        $this->service->populateData($spreadsheet, $data, $properties, 'default');
+
+        $sheet = $spreadsheet->getActiveSheet();
+        $this->assertSame("admin\nuser", $sheet->getCell([1,2])->getValue());
+    }
+
+    public function testPopulateDataManyToManySheet(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $reflection = new \ReflectionClass(UserWithRolesSheet::class);
+        $properties = $reflection->getProperties();
+        $this->service->generateMatrix($spreadsheet, $properties, [], 'default');
+
+        $data = [new UserWithRolesSheet([new Role('admin'), new Role('user')])];
+        $this->service->populateData($spreadsheet, $data, $properties, 'default');
+
+        $sheet = $spreadsheet->getSheetByName('roles');
+        $this->assertNotNull($sheet);
+        $this->assertSame('row', $sheet->getCell([1,1])->getValue());
+        $this->assertSame('name', $sheet->getCell([2,1])->getValue());
+        $this->assertSame(1, $sheet->getCell([1,2])->getValue());
+        $this->assertSame('admin', $sheet->getCell([2,2])->getValue());
+        $this->assertSame(1, $sheet->getCell([1,3])->getValue());
+        $this->assertSame('user', $sheet->getCell([2,3])->getValue());
+    }
 }
 
 #[Exportable]
@@ -60,7 +112,60 @@ class Dummy
     public string $email;
 }
 
+#[Exportable]
 class Role
 {
-    public function __construct(public string $name) {}
+    #[ExportableProperty(groups: ['default'])]
+    public string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}
+
+#[Exportable]
+class DummyWithMethod
+{
+    #[ExportableProperty(groups: ['default'])]
+    public string $firstName;
+
+    #[ExportableProperty(groups: ['default'])]
+    public string $lastName;
+
+    #[ExportableProperty(groups: ['default'])]
+    public function getFullName(): string
+    {
+        return $this->firstName.' '.$this->lastName;
+    }
+
+    public function __construct(string $firstName, string $lastName)
+    {
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
+    }
+}
+
+#[Exportable]
+class UserWithRolesLines
+{
+    #[ExportableProperty(groups: ['default'], manyToMany: ExportableProperty::MODE_LINES)]
+    public array $roles;
+
+    public function __construct(array $roles)
+    {
+        $this->roles = $roles;
+    }
+}
+
+#[Exportable]
+class UserWithRolesSheet
+{
+    #[ExportableProperty(groups: ['default'], manyToMany: ExportableProperty::MODE_SHEET)]
+    public array $roles;
+
+    public function __construct(array $roles)
+    {
+        $this->roles = $roles;
+    }
 }


### PR DESCRIPTION
## Summary
- restore logic handling many-to-many relations when populating data
- add runtime group selection and auto-detection of relation fields

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --testdox` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6842ac234ef883309bb101af670ad94a